### PR TITLE
Propagate errors to flask error handler

### DIFF
--- a/{{cookiecutter.project_name}}/{{cookiecutter.app_name}}/api/views.py
+++ b/{{cookiecutter.project_name}}/{{cookiecutter.app_name}}/api/views.py
@@ -7,7 +7,7 @@ from {{cookiecutter.app_name}}.api.schemas import UserSchema
 
 
 blueprint = Blueprint("api", __name__, url_prefix="/api/v1")
-api = Api(blueprint)
+api = Api(blueprint, errors=blueprint.errorhandler)
 
 
 api.add_resource(UserResource, "/users/<int:user_id>", endpoint="user_by_id")


### PR DESCRIPTION
This change makes the Flask-Restful API propagate errors to the Flask error handler.

This becomes kinda important with JWT authorization errors, as not propagating authorization exceptions will result in unhandled HTTP 500 errors.